### PR TITLE
Hippocampe as a service

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -9,6 +9,28 @@ import os
 import logging
 from logging.handlers import RotatingFileHandler
 import threading
+
+app_dir = os.path.dirname(os.path.abspath(__file__))
+
+#create logger
+logger = logging.getLogger('services')
+if not logger.handlers:
+	logger.setLevel(logging.DEBUG)
+	#log format as: 2013-03-08 11:37:31,411 :: WARNING :: Testing foo
+	formatter = logging.Formatter('%(asctime)s :: %(name)s :: %(levelname)s :: %(message)s')
+	#handler writes into , limited to 1Mo in append mode
+	if not os.path.exists('logs'):
+		#create logs directory if does not exist (tipically at first start)
+		os.makedirs('logs')
+	pathLog = app_dir + '/logs/hippocampe.log'
+	file_handler = RotatingFileHandler(pathLog, 'a', 1000000, 1)
+	#level debug
+	file_handler.setLevel(logging.DEBUG)
+	#using the format defined earlier
+	file_handler.setFormatter(formatter)
+	#Adding the file handler
+	logger.addHandler(file_handler)
+
 app = Flask(__name__, static_url_path='')
 @app.route('/hippocampe/api/v1.0/more', methods=['POST'])
 def moreService():
@@ -359,7 +381,6 @@ def index():
 		return render_template('index.html')
 
 if __name__ == '__main__':
-	app_dir = os.path.dirname(os.path.abspath(__file__))
 
 	##accessing Werkzeug’s logger and writing logs to file
 	##snippet from https://docstrings.wordpress.com/2014/04/19/flask-access-log-write-requests-to-file/
@@ -371,30 +392,6 @@ if __name__ == '__main__':
 	## Also add the handler to Flask's logger for cases
 	##  where Werkzeug isn't used as the underlying WSGI server.
 	#app.logger.addHandler(handlerWerkzeug)
-
- 	#create logger
-	logger = logging.getLogger('services')
-	if not logger.handlers:
-		logger.setLevel(logging.DEBUG)
-		#log format as: 2013-03-08 11:37:31,411 :: WARNING :: Testing foo
-		formatter = logging.Formatter('%(asctime)s :: %(name)s :: %(levelname)s :: %(message)s')
-		#handler writes into , limited to 1Mo in append mode
-		if not os.path.exists('logs'):
-			#create logs directory if does not exist (tipically at first start)
-			os.makedirs('logs')
-		pathLog = app_dir + '/logs/hippocampe.log'
-		file_handler = RotatingFileHandler(pathLog, 'a', 1000000, 1)
-		#level debug
-		file_handler.setLevel(logging.DEBUG)
-		#using the format defined earlier
-		file_handler.setFormatter(formatter)
-		#Adding the file handler
-		logger.addHandler(file_handler)
-
-        	#handler to print out logs in shell
-        	#steam_handler = logging.StreamHandler()
-        	#steam_handler.setLevel(logging.DEBUG)
-        	#logger.addHandler(steam_handler)
 
 	#loading general configuration file
 	cfg = getHippoConf()

--- a/docs/install_guide.md
+++ b/docs/install_guide.md
@@ -54,3 +54,164 @@ docker run -p 5000:5000 hippocampe
 ```
 
 Now Hippocampe is available on port 5000 and runs inside a docker.
+
+##Hippocampe as a service
+
+To turn Hippocampe into a service, the uWSGI tool and a NGINX server will be used.
+
+NGINX will host all the web content while uWSGI will execute the python code.
+
+In this example, Hippocampe is located at ```/opt/Hippocampe``` and configuration files for both nginx and uWSGI are located at ```/var/www/demoapp```.
+
+###Install NGINX
+
+```
+sudo apt-get install nginx
+```
+
+###Install uWSGI
+
+```
+sudo apt-get install build-essential python python-dev
+sudo pip install uwsgi
+```
+
+###Configuring nginx
+
+* Delete the default nginx's site
+
+```
+sudo rm /etc/nginx/sites-enabled/default
+```
+
+* Create the nginx's configuration file at ```/var/www/demoapp/hippo_nginx.conf```
+
+```
+sudo mkdir /var/www/demoapp
+```
+
+```
+server {
+    listen      80;
+    server_name localhost;
+    charset     utf-8;
+    client_max_body_size 75M;
+
+    location / { try_files $uri @hippocampe; }
+    location @hippocampe {
+        include uwsgi_params;
+        uwsgi_pass unix:/var/www/demoapp/demoapp_uwsgi.sock;
+    }
+}
+```
+
+* Link the file with nginx
+
+```
+sudo ln -s /var/www/demoapp/hippo_nginx.conf /etc/nginx/conf.d/
+sudo /etc/init.d/nginx restart
+```
+
+###Configuring uWSGI
+
+* Create the configuration file at ```/var/www/demoapp/demoapp_uwsgi.ini```
+
+```
+[uwsgi]
+#application's base folder
+chdir = /opt/Hippocampe/core
+
+#python module to import
+app = app
+module = %(app)
+
+processes = 8
+thread = 16
+enable-threads = true
+pythonpath = /usr/local/lib/python2.7/dist-packages
+pythonpath = /usr/lib/python2.7
+
+#socket file's location
+socket = /var/www/demoapp/%n.sock
+
+#permissions for the socket file
+chmod-socket    = 666
+
+#the variable that holds a flask application inside the module imported at line #6
+callable = app
+
+#location of log files
+logto = /var/www/demoapp/log/uwsgi/%n.log
+uid = www-data
+gid = www-data
+```
+
+* Create the folder for uWSGI's logs
+
+```
+sudo mkdir -p /var/www/demoapp/log/uwsgi
+```
+
+* Give the adequat rights
+
+```
+sudo chown -R www-data:www-data /var/www/demoapp/
+sudo chown -R www-data:www-data /opt/Hippocampe
+```
+
+###Turn all stuff into a service with ```systemctl```
+
+* Create the file ```/etc/systemd/system/uwsgi.service```
+
+```
+[Unit]
+Description=uWSGI for hippocampe demo
+After=syslog.target
+
+[Service]
+ExecStart=/usr/local/bin/uwsgi --master --emperor /etc/uwsgi/vassals --die-on-term --uid www-data --gid www-data --logto /var/www/demoapp/log/uwsgi/emperor.log
+Restart=always
+KillSignal=SIGQUIT
+Type=notify
+StandardError=syslog
+NotifyAccess=all
+
+[Install]
+WantedBy=multi-user.target
+```
+
+* Create the directory ```/etc/uwsgi/vassals```
+
+```
+sudo mkdir -p /etc/uwsgi/vassals
+```
+
+* Link the uWSGI config file to it
+
+```
+sudo ln -s /var/www/demoapp/demoapp_uwsgi.ini /etc/uwsgi/vassals
+```
+
+* Start the service
+
+```
+sudo systemctl daemon-reload
+sudo systemctl start uwsgi
+```
+
+###Test it
+
+Go to ```http://localhost/hippocampe``` and it should work.
+
+Moreover the API is now expose to port 80.
+
+###Logs path
+
+* Hippocampe's logs
+   * ```Hippocampe/core/logs/hippocampe.log```
+* nginx's logs
+   * ```/var/log/nginx/access.log```
+   * ```/var/log/nginx/error.log```
+* uWSGI's logs
+   * ```/var/www/demoapp/log/uwsgi/demoapp_uwsgi.log```
+   * ```/var/www/demoapp/log/uwsgi/emperor.log```


### PR DESCRIPTION
The documentation has been created to explain how to set Hippocampe up as a service.   
```app.py``` had to be modified as well to work properly as a service.